### PR TITLE
Fix committee board many to many relation

### DIFF
--- a/OleSync.Domain/Boards/Core/Entities/Committee.cs
+++ b/OleSync.Domain/Boards/Core/Entities/Committee.cs
@@ -1,25 +1,24 @@
 using OleSync.Domain.Boards.Core.ValueObjects;
+using System.Collections.Generic;
 
 namespace OleSync.Domain.Boards.Core.Entities
 {
     public class Committee
     {
         public int Id { get; private set; }
-        public int BoardId { get; private set; }
         public string Name { get; private set; } = null!;
         public string? Description { get; private set; }
         public AuditInfo Audit { get; private set; } = null!;
 
-        public Board Board { get; private set; } = null!;
+        public ICollection<Board> Boards { get; private set; } = new List<Board>();
 
-        public static Committee Create(int boardId, string name, string? description, AuditInfo audit)
+        public static Committee Create(string name, string? description, AuditInfo audit)
         {
             if (string.IsNullOrWhiteSpace(name))
                 throw new ArgumentException("Name cannot be empty.", nameof(name));
 
             return new Committee
             {
-                BoardId = boardId,
                 Name = name,
                 Description = description,
                 Audit = audit.CreateOnAdd(1)
@@ -38,12 +37,11 @@ namespace OleSync.Domain.Boards.Core.Entities
             Audit.SetOnDelete(deletedBy);
         }
 
-        public static Committee Rehydrate(int id, int boardId, string name, string? description, AuditInfo audit)
+        public static Committee Rehydrate(int id, string name, string? description, AuditInfo audit)
         {
             return new Committee
             {
                 Id = id,
-                BoardId = boardId,
                 Name = name,
                 Description = description,
                 Audit = audit

--- a/OleSync.Infrastructure/Migrations/20250825145834_Add_BoardCommittee_M2M.Designer.cs
+++ b/OleSync.Infrastructure/Migrations/20250825145834_Add_BoardCommittee_M2M.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using OleSync.Infrastructure.Persistence.Context;
 
@@ -11,9 +12,11 @@ using OleSync.Infrastructure.Persistence.Context;
 namespace OleSync.Infrastructure.Migrations
 {
     [DbContext(typeof(OleSyncContext))]
-    partial class OleSyncContextModelSnapshot : ModelSnapshot
+    [Migration("20250825145834_Add_BoardCommittee_M2M")]
+    partial class Add_BoardCommittee_M2M
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/OleSync.Infrastructure/Migrations/20250825145834_Add_BoardCommittee_M2M.cs
+++ b/OleSync.Infrastructure/Migrations/20250825145834_Add_BoardCommittee_M2M.cs
@@ -1,0 +1,168 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace OleSync.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class Add_BoardCommittee_M2M : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "BoardMembers",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    BoardId = table.Column<int>(type: "int", nullable: false),
+                    MemberType = table.Column<int>(type: "int", nullable: false),
+                    EmployeeId = table.Column<int>(type: "int", nullable: true),
+                    GuestId = table.Column<int>(type: "int", nullable: true),
+                    CreatedBy = table.Column<long>(type: "bigint", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "datetime", nullable: false),
+                    ModifiedBy = table.Column<long>(type: "bigint", nullable: true),
+                    ModifiedAt = table.Column<DateTime>(type: "datetime", nullable: true),
+                    Audit_IsDeleted = table.Column<bool>(type: "bit", nullable: false, defaultValue: false),
+                    DeletedBy = table.Column<long>(type: "bigint", nullable: true),
+                    DeletedAt = table.Column<DateTime>(type: "datetime", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_BoardMembers", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_BoardMembers_Boards_BoardId",
+                        column: x => x.BoardId,
+                        principalTable: "Boards",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Committees",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Name = table.Column<string>(type: "nvarchar(255)", maxLength: 255, nullable: false),
+                    Description = table.Column<string>(type: "nvarchar(500)", maxLength: 500, nullable: true),
+                    CreatedBy = table.Column<long>(type: "bigint", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "datetime", nullable: false),
+                    ModifiedBy = table.Column<long>(type: "bigint", nullable: true),
+                    ModifiedAt = table.Column<DateTime>(type: "datetime", nullable: true),
+                    Audit_IsDeleted = table.Column<bool>(type: "bit", nullable: false, defaultValue: false),
+                    DeletedBy = table.Column<long>(type: "bigint", nullable: true),
+                    DeletedAt = table.Column<DateTime>(type: "datetime", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Committees", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Employees",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    FullName = table.Column<string>(type: "nvarchar(255)", maxLength: 255, nullable: false),
+                    Email = table.Column<string>(type: "nvarchar(255)", maxLength: 255, nullable: true),
+                    Phone = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: true),
+                    Position = table.Column<int>(type: "int", nullable: false),
+                    Role = table.Column<int>(type: "int", nullable: false),
+                    MemberType = table.Column<int>(type: "int", nullable: false),
+                    CreatedBy = table.Column<long>(type: "bigint", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "datetime", nullable: false),
+                    ModifiedBy = table.Column<long>(type: "bigint", nullable: true),
+                    ModifiedAt = table.Column<DateTime>(type: "datetime", nullable: true),
+                    Audit_IsDeleted = table.Column<bool>(type: "bit", nullable: false, defaultValue: false),
+                    DeletedBy = table.Column<long>(type: "bigint", nullable: true),
+                    DeletedAt = table.Column<DateTime>(type: "datetime", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Employees", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Guests",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    FullName = table.Column<string>(type: "nvarchar(255)", maxLength: 255, nullable: false),
+                    Email = table.Column<string>(type: "nvarchar(255)", maxLength: 255, nullable: true),
+                    Phone = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: true),
+                    Position = table.Column<int>(type: "int", nullable: false),
+                    Role = table.Column<int>(type: "int", nullable: false),
+                    MemberType = table.Column<int>(type: "int", nullable: false),
+                    CreatedBy = table.Column<long>(type: "bigint", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "datetime", nullable: false),
+                    ModifiedBy = table.Column<long>(type: "bigint", nullable: true),
+                    ModifiedAt = table.Column<DateTime>(type: "datetime", nullable: true),
+                    Audit_IsDeleted = table.Column<bool>(type: "bit", nullable: false, defaultValue: false),
+                    DeletedBy = table.Column<long>(type: "bigint", nullable: true),
+                    DeletedAt = table.Column<DateTime>(type: "datetime", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Guests", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "BoardCommittees",
+                columns: table => new
+                {
+                    BoardId = table.Column<int>(type: "int", nullable: false),
+                    CommitteeId = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_BoardCommittees", x => new { x.BoardId, x.CommitteeId });
+                    table.ForeignKey(
+                        name: "FK_BoardCommittees_Boards_BoardId",
+                        column: x => x.BoardId,
+                        principalTable: "Boards",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_BoardCommittees_Committees_CommitteeId",
+                        column: x => x.CommitteeId,
+                        principalTable: "Committees",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_BoardCommittees_CommitteeId",
+                table: "BoardCommittees",
+                column: "CommitteeId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_BoardMembers_BoardId_EmployeeId_GuestId",
+                table: "BoardMembers",
+                columns: new[] { "BoardId", "EmployeeId", "GuestId" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "BoardCommittees");
+
+            migrationBuilder.DropTable(
+                name: "BoardMembers");
+
+            migrationBuilder.DropTable(
+                name: "Employees");
+
+            migrationBuilder.DropTable(
+                name: "Guests");
+
+            migrationBuilder.DropTable(
+                name: "Committees");
+        }
+    }
+}

--- a/OleSync.Infrastructure/Persistence/Context/OleSyncContext.cs
+++ b/OleSync.Infrastructure/Persistence/Context/OleSyncContext.cs
@@ -90,9 +90,24 @@ namespace OleSync.Infrastructure.Persistence.Context
                       .OnDelete(DeleteBehavior.Cascade);
 
                 entity.HasMany(e => e.Committees)
-                      .WithOne(c => c.Board)
-                      .HasForeignKey(c => c.BoardId)
-                      .OnDelete(DeleteBehavior.Cascade);
+                      .WithMany(c => c.Boards)
+                      .UsingEntity<Dictionary<string, object>>(
+                          "BoardCommittees",
+                          j => j
+                              .HasOne<Committee>()
+                              .WithMany()
+                              .HasForeignKey("CommitteeId")
+                              .OnDelete(DeleteBehavior.Cascade),
+                          j => j
+                              .HasOne<Board>()
+                              .WithMany()
+                              .HasForeignKey("BoardId")
+                              .OnDelete(DeleteBehavior.Cascade),
+                          j =>
+                          {
+                              j.ToTable("BoardCommittees");
+                              j.HasKey("BoardId", "CommitteeId");
+                          });
             });
 
             modelBuilder.Entity<BoardMember>(entity =>
@@ -180,7 +195,6 @@ namespace OleSync.Infrastructure.Persistence.Context
                 entity.HasKey(e => e.Id);
                 entity.Property(e => e.Id).ValueGeneratedOnAdd();
 
-                entity.Property(e => e.BoardId).IsRequired();
                 entity.Property(e => e.Name).IsRequired().HasMaxLength(255);
                 entity.Property(e => e.Description).HasMaxLength(500);
 


### PR DESCRIPTION
Establish a many-to-many relationship between `Board` and `Committee` entities to allow committees to be associated with multiple boards.

---
<a href="https://cursor.com/background-agent?bcId=bc-bf36ad06-b58a-4b00-9d1a-ac4122b732f8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bf36ad06-b58a-4b00-9d1a-ac4122b732f8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

