### PR TITLE
Update committee board relationship and manage members

### DIFF
--- a/OleSync.Application/Boards/Commands/CreateBoardCommandHandler.cs
+++ b/OleSync.Application/Boards/Commands/CreateBoardCommandHandler.cs
@@ -1,16 +1,23 @@
-﻿using MediatR;
+using MediatR;
 using OleSync.Application.Boards.Mapping;
 using OleSync.Application.Boards.Requests;
 using OleSync.Domain.Boards.Repositories;
+using OleSync.Domain.People.Repositories;
+using OleSync.Domain.People.Core.Entities;
+using OleSync.Domain.Boards.Core.ValueObjects;
+using OleSync.Domain.Shared.Enums;
+using System.Linq;
 
 namespace OleSync.Application.Boards.Commands
 {
     public class CreateBoardCommandHandler : IRequestHandler<CreateBoardCommandRequest, int>
     {
         private readonly IBoardRepository _repository;
-        public CreateBoardCommandHandler(IBoardRepository repository)
+        private readonly IGuestRepository _guestRepository;
+        public CreateBoardCommandHandler(IBoardRepository repository, IGuestRepository guestRepository)
         {
             _repository = repository;
+            _guestRepository = guestRepository;
         }
 
         public async Task<int> Handle(CreateBoardCommandRequest request, CancellationToken cancellationToken)
@@ -19,6 +26,43 @@ namespace OleSync.Application.Boards.Commands
 
             var board = request.Board.ToDomainEntity();
             await _repository.AddAsync(board);
+
+            // Process incoming members if provided
+            if (request.Board.Members != null && request.Board.Members.Any())
+            {
+                foreach (var memberDto in request.Board.Members)
+                {
+                    int? employeeId = memberDto.EmployeeId;
+                    int? guestId = memberDto.GuestId;
+
+                    // If no EmployeeId/GuestId and new guest details provided, create Guest
+                    if (!employeeId.HasValue && !guestId.HasValue && !string.IsNullOrWhiteSpace(memberDto.FullName))
+                    {
+                        var audit = AuditInfo.CreateEmpty();
+                        var guest = Guest.Create(
+                            memberDto.FullName!,
+                            memberDto.Email ?? string.Empty,
+                            memberDto.Phone ?? string.Empty,
+                            position: null,
+                            role: Role.Member,
+                            memberType: memberDto.MemberType,
+                            audit: audit);
+
+                        await _guestRepository.AddAsync(guest);
+                        guestId = guest.Id;
+                    }
+
+                    // Create board member
+                    var memberAudit = AuditInfo.CreateEmpty();
+                    var member = board.AddMember(
+                        memberDto.MemberType,
+                        employeeId,
+                        guestId,
+                        memberAudit);
+                    await _repository.AddMemberAsync(member);
+                }
+            }
+
             return board.Id;
         }
     }

--- a/OleSync.Application/Boards/Dtos/BoardMemberDtos.cs
+++ b/OleSync.Application/Boards/Dtos/BoardMemberDtos.cs
@@ -2,6 +2,18 @@ using OleSync.Domain.Shared.Enums;
 
 namespace OleSync.Application.Boards.Dtos
 {
+    public class UpsertBoardMemberDto
+    {
+        public MemberType MemberType { get; set; }
+        // link existing
+        public int? EmployeeId { get; set; }
+        public int? GuestId { get; set; }
+        // or create new guest
+        public string? FullName { get; set; }
+        public string? Email { get; set; }
+        public string? Phone { get; set; }
+    }
+
     public class AddBoardMemberDto
     {
         public int BoardId { get; set; }

--- a/OleSync.Application/Boards/Dtos/CreateOrUpdateBoardDto.cs
+++ b/OleSync.Application/Boards/Dtos/CreateOrUpdateBoardDto.cs
@@ -1,4 +1,4 @@
-﻿using OleSync.Domain.Shared.Enums;
+using OleSync.Domain.Shared.Enums;
 
 namespace OleSync.Application.Boards.Dtos
 {
@@ -12,5 +12,8 @@ namespace OleSync.Application.Boards.Dtos
         public DateTime? EndDate { get; set; }
         public Status Status { get; set; }
         public AuditInfoDto? Audit { get; } = null!;
+
+        // New: Members to create along with board
+        public List<UpsertBoardMemberDto>? Members { get; set; }
     }
 }

--- a/OleSync.Domain/Boards/Core/Entities/Committee.cs
+++ b/OleSync.Domain/Boards/Core/Entities/Committee.cs
@@ -5,21 +5,20 @@ namespace OleSync.Domain.Boards.Core.Entities
     public class Committee
     {
         public int Id { get; private set; }
-        public int BoardId { get; private set; }
         public string Name { get; private set; } = null!;
         public string? Description { get; private set; }
         public AuditInfo Audit { get; private set; } = null!;
 
-        public Board Board { get; private set; } = null!;
+        // Many-to-many navigation to Boards
+        public ICollection<Board> Boards { get; private set; } = new List<Board>();
 
-        public static Committee Create(int boardId, string name, string? description, AuditInfo audit)
+        public static Committee Create(string name, string? description, AuditInfo audit)
         {
             if (string.IsNullOrWhiteSpace(name))
                 throw new ArgumentException("Name cannot be empty.", nameof(name));
 
             return new Committee
             {
-                BoardId = boardId,
                 Name = name,
                 Description = description,
                 Audit = audit.CreateOnAdd(1)
@@ -38,12 +37,11 @@ namespace OleSync.Domain.Boards.Core.Entities
             Audit.SetOnDelete(deletedBy);
         }
 
-        public static Committee Rehydrate(int id, int boardId, string name, string? description, AuditInfo audit)
+        public static Committee Rehydrate(int id, string name, string? description, AuditInfo audit)
         {
             return new Committee
             {
                 Id = id,
-                BoardId = boardId,
                 Name = name,
                 Description = description,
                 Audit = audit
@@ -51,4 +49,3 @@ namespace OleSync.Domain.Boards.Core.Entities
         }
     }
 }
-

--- a/OleSync.Domain/People/Repositories/IGuestRepository.cs
+++ b/OleSync.Domain/People/Repositories/IGuestRepository.cs
@@ -1,4 +1,4 @@
-﻿using OleSync.Domain.People.Core.Entities;
+using OleSync.Domain.People.Core.Entities;
 using System.Linq.Expressions;
 
 namespace OleSync.Domain.People.Repositories
@@ -7,5 +7,6 @@ namespace OleSync.Domain.People.Repositories
     {
         Task<IEnumerable<Guest>> FilterByAsync(Expression<Func<Guest, bool>> filter);
         IQueryable<Guest> FilterBy(Expression<Func<Guest, bool>> filter);
+        Task AddAsync(Guest guest);
     }
 }

--- a/OleSync.Infrastructure/Boards/BoardRepository.cs
+++ b/OleSync.Infrastructure/Boards/BoardRepository.cs
@@ -89,6 +89,7 @@ namespace OleSync.Infrastructure.Boards
         {
             var board = await _context.Boards
                 .Include(b => b.Members)
+                .Include(b => b.Committees)
                 .FirstOrDefaultAsync(b => b.Id == id);
             return board;
         }

--- a/OleSync.Infrastructure/People/GuestRepository.cs
+++ b/OleSync.Infrastructure/People/GuestRepository.cs
@@ -1,4 +1,4 @@
-﻿using AutoMapper;
+using AutoMapper;
 using Microsoft.EntityFrameworkCore;
 using OleSync.Domain.People.Core.Entities;
 using OleSync.Domain.People.Repositories;
@@ -39,5 +39,11 @@ namespace OleSync.Infrastructure.People
             return Guests;
         }
 
+        public async Task AddAsync(Guest guest)
+        {
+            ArgumentNullException.ThrowIfNull(guest);
+            _context.Guests.Add(guest);
+            await _context.SaveChangesAsync();
+        }
     }
 }

--- a/OleSync.Infrastructure/Persistence/Context/OleSyncContext.cs
+++ b/OleSync.Infrastructure/Persistence/Context/OleSyncContext.cs
@@ -89,10 +89,22 @@ namespace OleSync.Infrastructure.Persistence.Context
                       .HasForeignKey(m => m.BoardId)
                       .OnDelete(DeleteBehavior.Cascade);
 
+                // Many-to-many: Board <-> Committee via join table BoardCommittees
                 entity.HasMany(e => e.Committees)
-                      .WithOne(c => c.Board)
-                      .HasForeignKey(c => c.BoardId)
-                      .OnDelete(DeleteBehavior.Cascade);
+                      .WithMany(c => c.Boards)
+                      .UsingEntity<Dictionary<string, object>>(
+                          "BoardCommittees",
+                          j => j
+                              .HasOne<Committee>()
+                              .WithMany()
+                              .HasForeignKey("CommitteeId")
+                              .OnDelete(DeleteBehavior.Cascade),
+                          j => j
+                              .HasOne<Board>()
+                              .WithMany()
+                              .HasForeignKey("BoardId")
+                              .OnDelete(DeleteBehavior.Cascade))
+                      .ToTable("BoardCommittees");
             });
 
             modelBuilder.Entity<BoardMember>(entity =>
@@ -179,8 +191,6 @@ namespace OleSync.Infrastructure.Persistence.Context
 
                 entity.HasKey(e => e.Id);
                 entity.Property(e => e.Id).ValueGeneratedOnAdd();
-
-                entity.Property(e => e.BoardId).IsRequired();
                 entity.Property(e => e.Name).IsRequired().HasMaxLength(255);
                 entity.Property(e => e.Description).HasMaxLength(500);
 


### PR DESCRIPTION
Implement many-to-many relationship between Board and Committee and allow creating BoardMembers, including new guests, during board creation.

The `CreateBoardCommandHandler` now processes an incoming list of `UpsertBoardMemberDto`s, which can link existing employees/guests or create new guest records, then associates them as `BoardMember`s with the new board. This addresses the requirement for a flexible board member registration process and correct committee-board relationship.

---
<a href="https://cursor.com/background-agent?bcId=bc-11a37486-020e-4523-883c-dffcbd4a895a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-11a37486-020e-4523-883c-dffcbd4a895a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

