### PR TITLE
Add status enum description and fix board member dto

### DIFF
--- a/OleSync.Application/Boards/Dtos/BoardListDto.cs
+++ b/OleSync.Application/Boards/Dtos/BoardListDto.cs
@@ -1,4 +1,4 @@
-﻿using OleSync.Domain.Shared.Enums;
+using OleSync.Domain.Shared.Enums;
 
 namespace OleSync.Application.Boards.Dtos
 {
@@ -11,6 +11,7 @@ namespace OleSync.Application.Boards.Dtos
         public DateTime? StartDate { get; set; }
         public DateTime? EndDate { get; set; }
         public Status Status { get; set; }
+        public string StatusDescription { get; set; } = null!;
         public long CreatedBy { get; set; }
         public DateTime CreatedAt { get; set; }
         public long? ModifiedBy { get; set; }

--- a/OleSync.Application/Boards/Mapping/BoardMappingExtentions.cs
+++ b/OleSync.Application/Boards/Mapping/BoardMappingExtentions.cs
@@ -1,6 +1,7 @@
 using OleSync.Application.Boards.Dtos;
 using OleSync.Domain.Boards.Core.Entities;
 using OleSync.Domain.Boards.Core.ValueObjects;
+using OleSync.Application.Utilities;
 
 namespace OleSync.Application.Boards.Mapping
 {
@@ -51,6 +52,7 @@ namespace OleSync.Application.Boards.Mapping
                 StartDate = board.StartDate,
                 EndDate = board.EndDate,
                 Status = board.Status,
+                StatusDescription = board.Status.GetDescription(),
                 CreatedBy = board.Audit.CreatedBy,
                 CreatedAt = board.Audit.CreatedAt,
                 ModifiedBy = board.Audit.ModifiedBy,

--- a/OleSync.Application/Utilities/EnumExtensions.cs
+++ b/OleSync.Application/Utilities/EnumExtensions.cs
@@ -1,0 +1,44 @@
+using System.ComponentModel;
+using System.Reflection;
+
+namespace OleSync.Application.Utilities
+{
+	public static class EnumExtensions
+	{
+		public static string GetDescription(this Enum value)
+		{
+			if (value == null)
+				return string.Empty;
+
+			var fieldInfo = value.GetType().GetField(value.ToString());
+			if (fieldInfo == null)
+				return value.ToString();
+
+			var attribute = fieldInfo.GetCustomAttribute<DescriptionAttribute>();
+			return attribute?.Description ?? value.ToString();
+		}
+	}
+}
+
+using System.ComponentModel;
+using System.Reflection;
+
+namespace OleSync.Application.Utilities
+{
+	public static class EnumExtensions
+	{
+		public static string GetDescription(this Enum value)
+		{
+			if (value == null)
+				return string.Empty;
+
+			var fieldInfo = value.GetType().GetField(value.ToString());
+			if (fieldInfo == null)
+				return value.ToString();
+
+			var attribute = fieldInfo.GetCustomAttribute<DescriptionAttribute>();
+			return attribute?.Description ?? value.ToString();
+		}
+	}
+}
+


### PR DESCRIPTION
Add `StatusDescription` to `BoardListDto` and populate it with the enum's description to fulfill user request.

---
<a href="https://cursor.com/background-agent?bcId=bc-2a8c262e-874b-46ca-8125-e15574746d31">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2a8c262e-874b-46ca-8125-e15574746d31">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

