### PR TITLE
Fix board creation member validation

### DIFF
--- a/OleSync.Application/Boards/Dtos/CreateBoardMemberDto.cs
+++ b/OleSync.Application/Boards/Dtos/CreateBoardMemberDto.cs
@@ -1,4 +1,4 @@
-﻿using OleSync.Domain.Shared.Enums;
+using OleSync.Domain.Shared.Enums;
 
 namespace OleSync.Application.Boards.Dtos
 {
@@ -6,9 +6,9 @@ namespace OleSync.Application.Boards.Dtos
     {
         public int? EmployeeId { get; set; }
         public int? GuestId { get; set; }
-        public string FullName { get; set; } = null!;
-        public string Email { get; set; } = null!;
-        public string Phone { get; set; } = null!;
+        public string? FullName { get; set; }
+        public string? Email { get; set; }
+        public string? Phone { get; set; }
         public string? Position { get; set; } = null!;
         public MemberType MemberType { get; set; }
         public MemberRole Role { get; set; }


### PR DESCRIPTION
Make `FullName`, `Email`, and `Phone` nullable in `CreateBoardMemberDto` to resolve unintended validation errors when `EmployeeId` or `GuestId` are specified for board members.

The non-nullable fields in the DTO caused ASP.NET model binding to implicitly treat them as required for all members, leading to validation errors even when a member was identified by `EmployeeId` or `GuestId`. Making them nullable allows the custom validator to enforce their presence only when necessary.

---
<a href="https://cursor.com/background-agent?bcId=bc-e8bd9ac5-3ee0-4351-b617-9f63de9d38ef">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e8bd9ac5-3ee0-4351-b617-9f63de9d38ef">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

