### PR TITLE
Fix board creation API exception

### DIFF
--- a/OleSync.API/Validators/BoardValidator/AddBoardMemberDtoValidator.cs
+++ b/OleSync.API/Validators/BoardValidator/AddBoardMemberDtoValidator.cs
@@ -11,12 +11,14 @@ namespace OleSync.API.Validators.BoardValidator
             RuleFor(x => x.MemberType).IsInEnum();
 
             RuleFor(x => new { x.EmployeeId, x.GuestId })
-                .Must(ids => !(ids.EmployeeId.HasValue && ids.GuestId.HasValue))
+                .Must(ids => !(Normalize(ids.EmployeeId).HasValue && Normalize(ids.GuestId).HasValue))
                 .WithMessage("Member cannot be both Employee and Guest");
 
             RuleFor(x => new { x.EmployeeId, x.GuestId })
-                .Must(ids => ids.EmployeeId.HasValue || ids.GuestId.HasValue)
+                .Must(ids => Normalize(ids.EmployeeId).HasValue || Normalize(ids.GuestId).HasValue)
                 .WithMessage("Either EmployeeId or GuestId must be provided");
+
+            static int? Normalize(int? id) => id.HasValue && id.Value == 0 ? null : id;
         }
     }
 }

--- a/OleSync.API/Validators/BoardValidator/CreateBoardMemberDtoValidator.cs
+++ b/OleSync.API/Validators/BoardValidator/CreateBoardMemberDtoValidator.cs
@@ -8,11 +8,11 @@ namespace OleSync.API.Validators.BoardValidator
 		public CreateBoardMemberDtoValidator()
 		{
 			RuleFor(x => new { x.EmployeeId, x.GuestId })
-				.Must(ids => !(ids.EmployeeId.HasValue && ids.GuestId.HasValue))
+				.Must(ids => !(Normalize(ids.EmployeeId).HasValue && Normalize(ids.GuestId).HasValue))
 				.WithMessage("Member cannot be both Employee and Guest");
 
 			// If neither EmployeeId nor GuestId provided, then require fields to create Guest
-			When(x => !x.EmployeeId.HasValue && !x.GuestId.HasValue, () =>
+			When(x => !Normalize(x.EmployeeId).HasValue && !Normalize(x.GuestId).HasValue, () =>
 			{
 				RuleFor(x => x.FullName)
 					.NotEmpty().WithMessage("FullName is required when not linking Employee or Guest");
@@ -25,6 +25,8 @@ namespace OleSync.API.Validators.BoardValidator
 				RuleFor(x => x.MemberType)
 					.IsInEnum().WithMessage("MemberType is required and must be valid");
 			});
+
+			static int? Normalize(int? id) => id.HasValue && id.Value == 0 ? null : id;
 		}
 	}
 }

--- a/OleSync.Application/Boards/Commands/CreateBoardCommandHandler.cs
+++ b/OleSync.Application/Boards/Commands/CreateBoardCommandHandler.cs
@@ -32,8 +32,8 @@ namespace OleSync.Application.Boards.Commands
             {
                 foreach (var memberDto in request.Board.Members)
                 {
-                    int? employeeId = memberDto.EmployeeId;
-                    int? guestId = memberDto.GuestId;
+                    int? employeeId = Normalize(memberDto.EmployeeId);
+                    int? guestId = Normalize(memberDto.GuestId);
 
                     // If no EmployeeId/GuestId and new guest details provided, create Guest
                     if (!employeeId.HasValue && !guestId.HasValue)
@@ -66,5 +66,7 @@ namespace OleSync.Application.Boards.Commands
 
             return board.Id;
         }
+
+        private static int? Normalize(int? id) => id.HasValue && id.Value == 0 ? null : id;
     }
 }


### PR DESCRIPTION
Normalize `EmployeeId` and `GuestId` to `null` when their value is `0` to prevent foreign key violations during board member creation.

The API was failing to create boards when `BoardMember` DTOs contained `EmployeeId` or `GuestId` as `0`. This `0` was being interpreted as a valid ID, leading to database foreign key constraint errors. By treating `0` as "not provided" (i.e., `null`), the system correctly creates new `Guest` entries when no existing ID is specified, or correctly uses provided non-zero IDs.

---
<a href="https://cursor.com/background-agent?bcId=bc-34a2370e-0fde-4782-9396-81374a85e4d7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-34a2370e-0fde-4782-9396-81374a85e4d7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

